### PR TITLE
Attach permission to autosort command

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -11,6 +11,7 @@ commands:
    autosort:
       description: Toggles auto-sorting options.
       usage: /AutoSort
+      permission: automaticinventory.sortchests
    depositall:
       description: Deposits your non-hotbar inventory into any nearby chests containing matching items.
       usage: /DepositAll


### PR DESCRIPTION
Added permission to prevent tab completion of the autosort command for those players without the proper permission.