### PR TITLE
Sort while inventory is open less often

### DIFF
--- a/src/me/ryanhamshire/AutomaticInventory/AIEventHandler.java
+++ b/src/me/ryanhamshire/AutomaticInventory/AIEventHandler.java
@@ -369,7 +369,7 @@ public class AIEventHandler implements Listener
             if(firstEmpty < 9) return;
             playerData.firstEmptySlot = firstEmpty; 
             PickupSortTask task = new PickupSortTask(player, playerData, inventory);
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AutomaticInventory.instance, task, 100L);
+            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(AutomaticInventory.instance, task, 10L);
         }
     }
 	

--- a/src/me/ryanhamshire/AutomaticInventory/AIEventHandler.java
+++ b/src/me/ryanhamshire/AutomaticInventory/AIEventHandler.java
@@ -377,6 +377,10 @@ public class AIEventHandler implements Listener
 	{
 	    if(featureEnabled(Features.SortInventory, player))
         {
+            // Dont sort inventory if any other inventory is open
+            if (player.getOpenInventory().getTopInventory().getType() != InventoryType.CRAFTING)
+                return;
+
             new InventorySorter(inventory, 9).run();
             
             if(!playerData.isGotInventorySortInfo())


### PR DESCRIPTION
Players were complaining that their inventory was sorting while using our /trash command (basically essentials disposal sign) or while viewing their inventory. 

- [adcf459](https://github.com/MLG-Fortress/AutomaticInventory/commit/adcf45968f858a15a13a5810a2a93b4c174f59c2) prevents the sort from executing if any inventory is open 

- [374f696](https://github.com/MLG-Fortress/AutomaticInventory/commit/374f696642ff626bff2c01719a36b436008e86ef) reduces the sort task delay after pickup from 5 seconds to .5 seconds. It will cause inventories be sorted slightly more often, but will prevent "seemingly random sorting of inventories" (player's words; the 5 second delay makes it hard to correlate the pickup event with the sorting- if players can better understand why its getting sorted, they will be able to control it's behavior better, and be happier with the experience)

I tested and could not find any side affects from these changes.

Feedback of course welcome.